### PR TITLE
Reduce default width of ResizableSidebar to 250 for improved layout

### DIFF
--- a/src/views/StoryEditor.vue
+++ b/src/views/StoryEditor.vue
@@ -29,8 +29,8 @@
       <!-- 左侧章节选择器 -->
       <ResizableSidebar 
         v-if="sidebarVisible" 
-        position="left"
-        :default-width="300"
+position="left"
+ :default-width="250"
         :min-width="200"
         :max-width="500"
         title="拖动调整章节面板宽度"


### PR DESCRIPTION
Reduce default width of the ResizableSidebar from 300 to 250.